### PR TITLE
Display joined missions and Switch badges for Missions

### DIFF
--- a/src/components/mission/MissionItem.js
+++ b/src/components/mission/MissionItem.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import { Badge, Button } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { joinMission, leaveMission } from '../../redux/mission/missions';
 
 const MissionItem = ({ mission }) => {
   const dispatch = useDispatch();
+
+  const renderBadge = () => (mission.isJoined ? <Badge bg="success">Active Member</Badge> : <Badge bg="secondary">Not a Member</Badge>);
 
   const handleJoinLeaveMission = () => {
     if (mission.isJoined) {
@@ -21,6 +23,7 @@ const MissionItem = ({ mission }) => {
       <td>
         <p>{mission.mission_description}</p>
       </td>
+      <td>{renderBadge()}</td>
       <td className="text-center">
         <Button variant={mission.isJoined ? 'outline-danger' : 'outline-primary'} onClick={handleJoinLeaveMission}>
           {mission.isJoined ? 'Leave' : 'Join'}
@@ -35,7 +38,6 @@ MissionItem.propTypes = {
     mission_id: PropTypes.string.isRequired,
     mission_name: PropTypes.string.isRequired,
     mission_description: PropTypes.string.isRequired,
-    wikipedia: PropTypes.string.isRequired,
     isJoined: PropTypes.bool.isRequired,
   }).isRequired,
 };

--- a/src/components/mission/MissionsList.js
+++ b/src/components/mission/MissionsList.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import { Table } from 'react-bootstrap';
 import { getMissions } from '../../redux/mission/missions';
 import MissionItem from './MissionItem';

--- a/src/components/mission/ProfileMissions.js
+++ b/src/components/mission/ProfileMissions.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+const ProfileMissions = () => {
+  const missions = useSelector((state) => state.missions);
+  const filteredMissions = missions.filter((mission) => mission.isJoined);
+
+  const renderList = () => {
+    const joinedMissions = filteredMissions.filter((mission) => mission.isJoined);
+    if (joinedMissions.length) {
+      return joinedMissions.map((mission) => (
+        <li key={mission.mission_id} className="list-group-item">
+          <p className="mission-name">
+            {mission.mission_name}
+          </p>
+        </li>
+      ));
+    }
+
+    return <li className="list-group-item not-joined">No missions joined</li>;
+  };
+
+  return (
+    <div className="wrapper">
+      <h2 className="my-missions">My Missions</h2>
+      <ul className="list-group">
+        {renderList()}
+      </ul>
+    </div>
+  );
+};
+
+export default ProfileMissions;

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,7 +1,14 @@
 import React from 'react';
+import ProfileMissions from '../components/mission/ProfileMissions';
 
-const MyProfileContainer = () => (
-  <div className="profileContainer" />
+const ProfileContainer = () => (
+  <div className="profileContainer">
+    <div className="row">
+      <div className="col-md-6">
+        <ProfileMissions />
+      </div>
+    </div>
+  </div>
 );
 
-export default MyProfileContainer;
+export default ProfileContainer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,17 +1,19 @@
-import { legacy_createStore as createStore, combineReducers, applyMiddleware } from 'redux';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import logger from 'redux-logger';
+import missionsReducer from './mission/missionsReducer';
 import reducerRockets from './rockets/rocketsReducer';
-import missionsReducer from './mission/fetchMissions';
 
 const rootReducer = combineReducers({
   Rockets: reducerRockets,
   missions: missionsReducer,
 });
 
-const store = createStore(
-  rootReducer,
-  applyMiddleware(thunk, logger),
-);
+const middleware = [thunk, logger];
+
+const store = configureStore({
+  reducer: rootReducer,
+  middleware,
+});
 
 export default store;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,7 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import logger from 'redux-logger';
-import missionsReducer from './mission/missionsReducer';
+import missionsReducer from './mission/missions';
 import reducerRockets from './rockets/rocketsReducer';
 
 const rootReducer = combineReducers({


### PR DESCRIPTION
Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).

Render a list of all joined missions (use filter()) on the "My profile" page.